### PR TITLE
Add PHP todo app with admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# todo-app-5
-todo app 5 description
+# Todo App
+
+A lightweight todo list application built with raw PHP, MySQL, vanilla JavaScript, and CSS. The project also includes an administration area for managing tasks and authenticating privileged users.
+
+## Features
+
+- Create, update, and delete todo items from the public interface.
+- Live updates without reloading the page via a small JSON API.
+- Administrative dashboard with authentication to oversee every task.
+- Graceful fallbacks so the app remains usable without JavaScript.
+
+## Requirements
+
+- PHP 8.1+
+- MySQL 5.7+ or MariaDB 10.4+
+- Composer is **not** required; the app uses no external PHP dependencies.
+
+## Installation
+
+1. Copy the project files to your web server.
+2. Create a new MySQL database and user, then import the schema:
+
+   ```sql
+   SOURCE /path/to/schema.sql;
+   ```
+
+3. Update the database credentials in [`config.php`](config.php).
+4. Generate a password hash for the admin user defined in `schema.sql` and replace the placeholder value. You can use PHP's CLI for this:
+
+   ```bash
+   php -r "echo password_hash('your-password', PASSWORD_DEFAULT), PHP_EOL;"
+   ```
+
+5. Start the PHP development server for local testing:
+
+   ```bash
+   php -S 0.0.0.0:8000 -t public
+   ```
+
+6. Visit `http://localhost:8000` to use the public todo list or `http://localhost:8000/admin/login.php` to sign in as an administrator.
+
+## Project Structure
+
+```
+public/
+├── index.php          # Public todo list UI
+├── api.php            # JSON API for AJAX interactions
+├── assets/
+│   ├── app.js         # Front-end behaviour
+│   └── styles.css     # Styling for the app and auth pages
+└── admin/
+    ├── dashboard.php  # Admin dashboard for managing tasks
+    ├── login.php      # Administrator authentication
+    └── logout.php     # Session termination
+includes/
+├── bootstrap.php      # Starts session and loads shared utilities
+├── db.php             # Database connection helper
+├── auth.php           # Admin authentication helpers
+└── task_repository.php# Data-access helpers for todos
+config.php             # Database credentials
+schema.sql             # Database schema and seed admin user
+```
+
+## Security Notes
+
+- Always use HTTPS in production and configure strong database credentials.
+- Change the default admin account after installation and create additional accounts as required.
+- Configure your web server so that only the `public/` directory is web-accessible.
+
+## License
+
+This project is provided as-is without any specific license. Adapt it to suit your needs.

--- a/config.php
+++ b/config.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Basic database configuration for the Todo application.
+ *
+ * Update these constants to match your MySQL setup. The default values are
+ * suitable for local development when using the built-in PHP server and a
+ * MySQL instance running on the same machine.
+ */
+const DB_HOST = '127.0.0.1';
+const DB_PORT = 3306;
+const DB_NAME = 'todo_app';
+const DB_USER = 'todo_user';
+const DB_PASSWORD = 'todo_pass';
+
+/**
+ * Optional: adjust the timezone used by the application.
+ */
+date_default_timezone_set('UTC');

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+const ADMIN_SESSION_KEY = 'admin_user_id';
+
+function find_user_by_email(PDO $pdo, string $email): ?array
+{
+    $stmt = $pdo->prepare('SELECT id, email, password_hash, display_name, is_admin FROM users WHERE email = :email LIMIT 1');
+    $stmt->execute([':email' => $email]);
+    $user = $stmt->fetch();
+
+    return $user === false ? null : $user;
+}
+
+function verify_admin_credentials(PDO $pdo, string $email, string $password): ?array
+{
+    $user = find_user_by_email($pdo, $email);
+
+    if ($user === null || (int) $user['is_admin'] !== 1) {
+        return null;
+    }
+
+    if (!password_verify($password, $user['password_hash'])) {
+        return null;
+    }
+
+    return $user;
+}
+
+function login_admin(array $user): void
+{
+    $_SESSION[ADMIN_SESSION_KEY] = $user['id'];
+    $_SESSION['admin_display_name'] = $user['display_name'];
+}
+
+function logout_admin(): void
+{
+    unset($_SESSION[ADMIN_SESSION_KEY], $_SESSION['admin_display_name']);
+}
+
+function is_admin_logged_in(): bool
+{
+    return isset($_SESSION[ADMIN_SESSION_KEY]);
+}
+
+function require_admin(): void
+{
+    if (!is_admin_logged_in()) {
+        header('Location: /admin/login.php');
+        exit;
+    }
+}

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+session_start();
+
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/task_repository.php';
+require_once __DIR__ . '/auth.php';
+
+$pdo = null;
+$dbError = null;
+
+try {
+    $pdo = get_db_connection();
+} catch (PDOException $exception) {
+    $dbError = $exception->getMessage();
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+
+/**
+ * Creates (or reuses) a PDO connection to the configured MySQL database.
+ *
+ * @throws PDOException when the connection cannot be established.
+ */
+function get_db_connection(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo instanceof PDO) {
+        return $pdo;
+    }
+
+    $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s;charset=utf8mb4', DB_HOST, DB_PORT, DB_NAME);
+
+    $pdo = new PDO(
+        $dsn,
+        DB_USER,
+        DB_PASSWORD,
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]
+    );
+
+    return $pdo;
+}

--- a/includes/task_repository.php
+++ b/includes/task_repository.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Fetches all tasks ordered by creation date (newest first).
+ */
+function get_all_tasks(PDO $pdo): array
+{
+    $stmt = $pdo->query('SELECT id, title, description, is_completed, created_at, updated_at FROM todos ORDER BY created_at DESC');
+    return $stmt->fetchAll();
+}
+
+/**
+ * Creates a new todo entry.
+ */
+function create_task(PDO $pdo, string $title, ?string $description = null): int
+{
+    $stmt = $pdo->prepare('INSERT INTO todos (title, description) VALUES (:title, :description)');
+    $stmt->execute([
+        ':title' => $title,
+        ':description' => $description,
+    ]);
+
+    return (int) $pdo->lastInsertId();
+}
+
+/**
+ * Fetches a single todo item by its identifier.
+ */
+function find_task(PDO $pdo, int $taskId): ?array
+{
+    $stmt = $pdo->prepare('SELECT id, title, description, is_completed, created_at, updated_at FROM todos WHERE id = :id');
+    $stmt->execute([':id' => $taskId]);
+    $task = $stmt->fetch();
+
+    return $task === false ? null : $task;
+}
+
+/**
+ * Updates the completion status of a todo entry.
+ */
+function update_task_completion(PDO $pdo, int $taskId, bool $completed): void
+{
+    $stmt = $pdo->prepare('UPDATE todos SET is_completed = :completed, updated_at = NOW() WHERE id = :id');
+    $stmt->execute([
+        ':id' => $taskId,
+        ':completed' => $completed ? 1 : 0,
+    ]);
+}
+
+/**
+ * Deletes a todo entry.
+ */
+function delete_task(PDO $pdo, int $taskId): void
+{
+    $stmt = $pdo->prepare('DELETE FROM todos WHERE id = :id');
+    $stmt->execute([':id' => $taskId]);
+}

--- a/public/admin/dashboard.php
+++ b/public/admin/dashboard.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+require_admin();
+
+$message = null;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo instanceof PDO) {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title === '') {
+            $error = 'The task title cannot be empty.';
+        } else {
+            create_task($pdo, $title, $description !== '' ? $description : null);
+            $message = 'Task created successfully.';
+        }
+    } elseif ($action === 'toggle') {
+        $taskId = (int) ($_POST['task_id'] ?? 0);
+        $isCompleted = ((int) ($_POST['is_completed'] ?? 0)) === 1;
+        update_task_completion($pdo, $taskId, !$isCompleted);
+        $message = 'Task updated.';
+    } elseif ($action === 'delete') {
+        $taskId = (int) ($_POST['task_id'] ?? 0);
+        delete_task($pdo, $taskId);
+        $message = 'Task deleted.';
+    }
+}
+
+$tasks = $pdo instanceof PDO ? get_all_tasks($pdo) : [];
+$adminName = $_SESSION['admin_display_name'] ?? 'Administrator';
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin dashboard</title>
+    <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <div>
+            <h1>Admin dashboard</h1>
+            <p class="muted">Signed in as <?= htmlspecialchars($adminName); ?></p>
+        </div>
+        <nav>
+            <a href="/">View site</a>
+            <a href="/admin/logout.php">Sign out</a>
+        </nav>
+    </header>
+
+    <main class="layout">
+        <section class="panel">
+            <h2>Create a task</h2>
+            <?php if ($error !== null): ?>
+                <div class="alert alert-error"><?= htmlspecialchars($error); ?></div>
+            <?php elseif ($message !== null): ?>
+                <div class="alert"><?= htmlspecialchars($message); ?></div>
+            <?php endif; ?>
+            <?php if ($dbError !== null): ?>
+                <div class="alert alert-error">Database connection error: <?= htmlspecialchars($dbError); ?></div>
+            <?php endif; ?>
+
+            <form method="post" class="stack">
+                <input type="hidden" name="action" value="create">
+                <label>
+                    <span>Title</span>
+                    <input type="text" name="title" required>
+                </label>
+                <label>
+                    <span>Description <small>(optional)</small></span>
+                    <textarea name="description" rows="3"></textarea>
+                </label>
+                <button type="submit" class="button">Create task</button>
+            </form>
+        </section>
+
+        <section class="panel">
+            <h2>All tasks</h2>
+            <div class="task-list">
+                <?php if ($pdo === null): ?>
+                    <p class="muted">Connect to the database to manage tasks.</p>
+                <?php elseif (empty($tasks)): ?>
+                    <p class="muted">No tasks yet.</p>
+                <?php else: ?>
+                    <?php foreach ($tasks as $task): ?>
+                        <article class="task <?= $task['is_completed'] ? 'is-complete' : ''; ?>">
+                            <header>
+                                <div>
+                                    <h3><?= htmlspecialchars($task['title']); ?></h3>
+                                    <p class="muted">Created <?= htmlspecialchars($task['created_at']); ?></p>
+                                </div>
+                                <div class="task-actions">
+                                    <form method="post">
+                                        <input type="hidden" name="action" value="toggle">
+                                        <input type="hidden" name="task_id" value="<?= (int) $task['id']; ?>">
+                                        <input type="hidden" name="is_completed" value="<?= (int) $task['is_completed']; ?>">
+                                        <button type="submit" class="button button-secondary">
+                                            <?= $task['is_completed'] ? 'Mark incomplete' : 'Mark complete'; ?>
+                                        </button>
+                                    </form>
+                                    <form method="post" onsubmit="return confirm('Delete this task?');">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="task_id" value="<?= (int) $task['id']; ?>">
+                                        <button type="submit" class="button button-danger">Delete</button>
+                                    </form>
+                                </div>
+                            </header>
+                            <?php if (!empty($task['description'])): ?>
+                                <p><?= htmlspecialchars($task['description']); ?></p>
+                            <?php endif; ?>
+                            <?php if (!empty($task['updated_at']) && $task['updated_at'] !== $task['created_at']): ?>
+                                <footer>
+                                    <small>Updated <?= htmlspecialchars($task['updated_at']); ?></small>
+                                </footer>
+                            <?php endif; ?>
+                        </article>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </section>
+    </main>
+</body>
+</html>

--- a/public/admin/login.php
+++ b/public/admin/login.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+if (is_admin_logged_in()) {
+    header('Location: /admin/dashboard.php');
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo instanceof PDO) {
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($email === '' || $password === '') {
+        $error = 'Please provide both an email address and password.';
+    } else {
+        $user = verify_admin_credentials($pdo, $email, $password);
+
+        if ($user === null) {
+            $error = 'Invalid credentials or insufficient permissions.';
+        } else {
+            login_admin($user);
+            header('Location: /admin/dashboard.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin login</title>
+    <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body class="auth-layout">
+    <main class="auth-panel">
+        <h1>Admin login</h1>
+        <?php if ($dbError !== null): ?>
+            <div class="alert alert-error">Database connection error: <?= htmlspecialchars($dbError); ?></div>
+        <?php endif; ?>
+
+        <?php if ($error !== null): ?>
+            <div class="alert alert-error"><?= htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+
+        <form method="post" class="stack">
+            <label>
+                <span>Email address</span>
+                <input type="email" name="email" required autofocus>
+            </label>
+            <label>
+                <span>Password</span>
+                <input type="password" name="password" required>
+            </label>
+            <button type="submit" class="button">Sign in</button>
+        </form>
+        <p class="muted"><a href="/">Back to the todo list</a></p>
+    </main>
+</body>
+</html>

--- a/public/admin/logout.php
+++ b/public/admin/logout.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../includes/bootstrap.php';
+
+logout_admin();
+
+header('Location: /admin/login.php');
+exit;

--- a/public/api.php
+++ b/public/api.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+header('Content-Type: application/json');
+
+if (!$pdo instanceof PDO) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database connection not available.']);
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    echo json_encode(get_all_tasks($pdo));
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed.']);
+    exit;
+}
+
+$input = file_get_contents('php://input');
+$data = json_decode($input, true);
+
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid request.']);
+    exit;
+}
+
+$action = $data['action'] ?? '';
+
+switch ($action) {
+    case 'create':
+        $title = trim((string) ($data['title'] ?? ''));
+        $description = trim((string) ($data['description'] ?? ''));
+
+        if ($title === '') {
+            http_response_code(422);
+            echo json_encode(['error' => 'Title is required.']);
+            exit;
+        }
+
+        $taskId = create_task($pdo, $title, $description !== '' ? $description : null);
+        $task = find_task($pdo, $taskId);
+        echo json_encode($task);
+        break;
+
+    case 'toggle':
+        $taskId = (int) ($data['task_id'] ?? 0);
+        $isCompleted = (bool) ($data['is_completed'] ?? false);
+
+        update_task_completion($pdo, $taskId, $isCompleted);
+        $task = find_task($pdo, $taskId);
+        echo json_encode($task);
+        break;
+
+    case 'delete':
+        $taskId = (int) ($data['task_id'] ?? 0);
+        delete_task($pdo, $taskId);
+        echo json_encode(['status' => 'deleted']);
+        break;
+
+    default:
+        http_response_code(400);
+        echo json_encode(['error' => 'Unknown action.']);
+        break;
+}

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -1,0 +1,160 @@
+const form = document.getElementById('create-task-form');
+const taskList = document.getElementById('task-list');
+const hasConnection = taskList && taskList.dataset.hasConnection === '1';
+
+async function fetchTasks() {
+    if (!hasConnection) {
+        return;
+    }
+
+    const response = await fetch('/api.php');
+    if (!response.ok) {
+        console.error('Unable to fetch tasks');
+        return;
+    }
+
+    const tasks = await response.json();
+    renderTasks(tasks);
+}
+
+function renderTasks(tasks) {
+    if (!taskList) {
+        return;
+    }
+
+    if (!Array.isArray(tasks)) {
+        return;
+    }
+
+    taskList.innerHTML = '';
+
+    if (tasks.length === 0) {
+        taskList.innerHTML = '<p class="muted">No tasks yet. Add one using the form above.</p>';
+        return;
+    }
+
+    for (const task of tasks) {
+        const article = document.createElement('article');
+        article.className = `task ${task.is_completed ? 'is-complete' : ''}`;
+        article.dataset.taskId = task.id;
+
+        const header = document.createElement('header');
+        const heading = document.createElement('h3');
+        heading.textContent = task.title;
+        header.appendChild(heading);
+
+        const actions = document.createElement('div');
+        actions.className = 'task-actions';
+
+        const toggleButton = document.createElement('button');
+        toggleButton.className = 'button button-secondary';
+        toggleButton.type = 'button';
+        toggleButton.textContent = task.is_completed ? 'Mark incomplete' : 'Mark complete';
+        toggleButton.addEventListener('click', () => toggleTask(task.id, !task.is_completed));
+
+        const deleteButton = document.createElement('button');
+        deleteButton.className = 'button button-danger';
+        deleteButton.type = 'button';
+        deleteButton.textContent = 'Delete';
+        deleteButton.addEventListener('click', () => {
+            if (confirm('Delete this task?')) {
+                deleteTask(task.id);
+            }
+        });
+
+        actions.append(toggleButton, deleteButton);
+        header.appendChild(actions);
+        article.appendChild(header);
+
+        if (task.description) {
+            const description = document.createElement('p');
+            description.textContent = task.description;
+            article.appendChild(description);
+        }
+
+        const footer = document.createElement('footer');
+        const created = document.createElement('small');
+        created.textContent = `Created ${task.created_at}`;
+        footer.appendChild(created);
+
+        if (task.updated_at && task.updated_at !== task.created_at) {
+            const updated = document.createElement('small');
+            updated.textContent = `Updated ${task.updated_at}`;
+            footer.appendChild(updated);
+        }
+
+        article.appendChild(footer);
+        taskList.appendChild(article);
+    }
+}
+
+async function createTask(data) {
+    const response = await fetch('/api.php', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'create', ...data })
+    });
+
+    if (!response.ok) {
+        alert('Unable to create task.');
+        return;
+    }
+
+    const task = await response.json();
+    form.reset();
+    await fetchTasks();
+    return task;
+}
+
+async function toggleTask(taskId, isCompleted) {
+    const response = await fetch('/api.php', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'toggle', task_id: taskId, is_completed: isCompleted })
+    });
+
+    if (!response.ok) {
+        alert('Unable to update task.');
+        return;
+    }
+
+    await fetchTasks();
+}
+
+async function deleteTask(taskId) {
+    const response = await fetch('/api.php', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'delete', task_id: taskId })
+    });
+
+    if (!response.ok) {
+        alert('Unable to delete task.');
+        return;
+    }
+
+    await fetchTasks();
+}
+
+if (form && hasConnection) {
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const formData = new FormData(form);
+        const title = formData.get('title')?.toString().trim();
+        const description = formData.get('description')?.toString().trim();
+
+        if (!title) {
+            return;
+        }
+
+        await createTask({ title, description });
+    });
+
+    fetchTasks();
+}

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -1,0 +1,252 @@
+:root {
+    color-scheme: light dark;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    line-height: 1.5;
+    font-size: 16px;
+    --surface: #ffffff;
+    --border: #d1d5db;
+    --background: #f3f4f6;
+    --text: #111827;
+    --muted: #6b7280;
+    --accent: #2563eb;
+    --accent-contrast: #ffffff;
+    --danger: #dc2626;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --surface: #1f2937;
+        --border: #374151;
+        --background: #111827;
+        --text: #f9fafb;
+        --muted: #9ca3af;
+        --accent: #60a5fa;
+        --accent-contrast: #111827;
+        --danger: #f87171;
+    }
+}
+
+body {
+    margin: 0;
+    background: var(--background);
+    color: var(--text);
+}
+
+.site-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 2rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.site-header nav {
+    display: flex;
+    gap: 1rem;
+}
+
+.site-header a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.layout {
+    display: grid;
+    gap: 2rem;
+    padding: 2rem;
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+@media (min-width: 768px) {
+    .layout {
+        grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+        align-items: start;
+    }
+}
+
+.panel {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 15px 35px -25px rgba(0, 0, 0, 0.5);
+}
+
+.panel h2 {
+    margin-top: 0;
+}
+
+.stack {
+    display: grid;
+    gap: 1rem;
+}
+
+label span {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+input[type="text"],
+textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    font: inherit;
+    background: transparent;
+    color: inherit;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.button {
+    padding: 0.75rem 1.25rem;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    background: var(--accent);
+    color: var(--accent-contrast);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 15px 30px -20px rgba(37, 99, 235, 0.6);
+}
+
+.button-secondary {
+    background: transparent;
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+.button-secondary:hover {
+    box-shadow: none;
+    transform: none;
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.button-danger {
+    background: var(--danger);
+    color: #fff;
+}
+
+.button-danger:hover {
+    box-shadow: 0 12px 24px -18px rgba(220, 38, 38, 0.8);
+}
+
+.task-list {
+    display: grid;
+    gap: 1rem;
+}
+
+.task {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem;
+    background: var(--surface);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.task p {
+    margin: 0;
+    white-space: pre-wrap;
+}
+
+.task header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.task h3 {
+    margin: 0;
+}
+
+.task-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.task footer {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.875rem;
+    color: var(--muted);
+}
+
+.task.is-complete {
+    opacity: 0.7;
+}
+
+.task.is-complete h3 {
+    text-decoration: line-through;
+}
+
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    background: rgba(37, 99, 235, 0.12);
+    border: 1px solid rgba(37, 99, 235, 0.3);
+    color: var(--accent);
+}
+
+.alert-error {
+    background: rgba(220, 38, 38, 0.15);
+    border: 1px solid rgba(220, 38, 38, 0.5);
+    color: #991b1b;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+code {
+    background: rgba(148, 163, 184, 0.2);
+    padding: 0.1rem 0.35rem;
+    border-radius: 6px;
+}
+
+.auth-layout {
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--background);
+}
+
+.auth-panel {
+    width: min(400px, 90vw);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2rem;
+    box-shadow: 0 20px 35px -30px rgba(0, 0, 0, 0.6);
+}
+
+.auth-panel h1 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+}
+
+.auth-panel a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.auth-panel a:hover {
+    text-decoration: underline;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,115 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../includes/bootstrap.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $pdo instanceof PDO) {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $title = trim($_POST['title'] ?? '');
+        $description = trim($_POST['description'] ?? '');
+
+        if ($title !== '') {
+            create_task($pdo, $title, $description !== '' ? $description : null);
+        }
+    } elseif ($action === 'toggle') {
+        $taskId = (int) ($_POST['task_id'] ?? 0);
+        $isCompleted = ((int) ($_POST['is_completed'] ?? 0)) === 1;
+        update_task_completion($pdo, $taskId, !$isCompleted);
+    } elseif ($action === 'delete') {
+        $taskId = (int) ($_POST['task_id'] ?? 0);
+        delete_task($pdo, $taskId);
+    }
+
+    header('Location: /');
+    exit;
+}
+
+$tasks = $pdo instanceof PDO ? get_all_tasks($pdo) : [];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo List</title>
+    <link rel="stylesheet" href="/assets/styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>Todo List</h1>
+        <nav>
+            <a href="/admin/login.php">Admin</a>
+        </nav>
+    </header>
+
+    <main class="layout">
+        <section class="panel">
+            <h2>Add a new task</h2>
+            <?php if ($dbError !== null): ?>
+                <div class="alert alert-error">
+                    Unable to connect to the database: <?= htmlspecialchars($dbError); ?>
+                </div>
+            <?php endif; ?>
+            <form id="create-task-form" method="post" class="stack">
+                <input type="hidden" name="action" value="create">
+                <label>
+                    <span>Title</span>
+                    <input type="text" name="title" placeholder="Buy groceries" required>
+                </label>
+                <label>
+                    <span>Description <small>(optional)</small></span>
+                    <textarea name="description" rows="3" placeholder="Milk, bread, cheese..."></textarea>
+                </label>
+                <button type="submit" class="button">Add task</button>
+            </form>
+        </section>
+
+        <section class="panel">
+            <h2>Current tasks</h2>
+            <div id="task-list" class="task-list" data-has-connection="<?= $pdo instanceof PDO ? '1' : '0'; ?>">
+                <?php if ($pdo === null): ?>
+                    <p class="muted">Set up the database connection in <code>config.php</code> to start tracking tasks.</p>
+                <?php elseif (empty($tasks)): ?>
+                    <p class="muted">No tasks yet. Add one using the form above.</p>
+                <?php else: ?>
+                    <?php foreach ($tasks as $task): ?>
+                        <article class="task <?= $task['is_completed'] ? 'is-complete' : ''; ?>" data-task-id="<?= (int) $task['id']; ?>">
+                            <header>
+                                <h3><?= htmlspecialchars($task['title']); ?></h3>
+                                <div class="task-actions">
+                                    <form method="post">
+                                        <input type="hidden" name="action" value="toggle">
+                                        <input type="hidden" name="task_id" value="<?= (int) $task['id']; ?>">
+                                        <input type="hidden" name="is_completed" value="<?= (int) $task['is_completed']; ?>">
+                                        <button type="submit" class="button button-secondary">
+                                            <?= $task['is_completed'] ? 'Mark incomplete' : 'Mark complete'; ?>
+                                        </button>
+                                    </form>
+                                    <form method="post" onsubmit="return confirm('Delete this task?');">
+                                        <input type="hidden" name="action" value="delete">
+                                        <input type="hidden" name="task_id" value="<?= (int) $task['id']; ?>">
+                                        <button type="submit" class="button button-danger">Delete</button>
+                                    </form>
+                                </div>
+                            </header>
+                            <?php if (!empty($task['description'])): ?>
+                                <p><?= htmlspecialchars($task['description']); ?></p>
+                            <?php endif; ?>
+                            <footer>
+                                <small>Created <?= htmlspecialchars($task['created_at']); ?></small>
+                                <?php if (!empty($task['updated_at']) && $task['updated_at'] !== $task['created_at']): ?>
+                                    <small>Updated <?= htmlspecialchars($task['updated_at']); ?></small>
+                                <?php endif; ?>
+                            </footer>
+                        </article>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </section>
+    </main>
+
+    <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    display_name VARCHAR(100) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    is_admin TINYINT(1) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE todos (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    description TEXT NULL,
+    is_completed TINYINT(1) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO users (email, display_name, password_hash, is_admin)
+VALUES (
+    'admin@example.com',
+    'Site Administrator',
+    -- Replace the hash below with the output of `password_hash('your-password', PASSWORD_DEFAULT)`
+    '$2y$10$exampleexampleexampleexampleexampleexampleexampleexample',
+    1
+);


### PR DESCRIPTION
## Summary
- build a raw PHP todo application with a JSON API, admin authentication, and graceful fallbacks
- add vanilla JavaScript and CSS for interactive task management and modern styling
- document setup instructions, database schema, and configuration details

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68d8e8a33b3c8330b829e5fd09224541